### PR TITLE
Return $DOKKU_NOT_IMPLEMENTED_EXIT when an unsupported command is called.

### DIFF
--- a/commands
+++ b/commands
@@ -249,4 +249,7 @@ case "$1" in
   help)
     cat && print_help
   ;;
+  *)
+    exit $DOKKU_NOT_IMPLEMENTED_EXIT
+  ;;
 esac


### PR DESCRIPTION
Please note that such return code has been introduced in dokku with the commit d307a5b8.

Thanks for considering.