### PR TITLE
Fix file existence detection

### DIFF
--- a/install
+++ b/install
@@ -9,7 +9,7 @@ if [[ ! -d "$SHARED_HOSTKEYS_FOLDER" ]]
   mkdir -p "$SHARED_HOSTKEYS_FOLDER";
 fi
 
-if [[ ! -d "$SHARED_HOSTKEYS_FOLDER/known_hosts" ]]
+if [[ ! -f "$SHARED_HOSTKEYS_FOLDER/known_hosts" ]]
  then
   touch "$SHARED_HOSTKEYS_FOLDER/known_hosts";
 fi


### PR DESCRIPTION
known_hosts can be a regular file, so test -d does
not apply very well.