### PR TITLE
Add plugin.toml to silence failure messages on deploy

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,9 +53,6 @@ $ dokku hostkeys:shared:autoadd mycoolapp github.com
 This command would automatically discover the hostkeys for github.com, add it to your known_hosts
 file for the mycoolapp app and will be compiled inside the slug on recompile.
 
-$ dokku hostkeys:shared:autoadd github.com
-This command would automatically discover the hostkeys for github.com and add it to your apps slug.
-
 You may as well want to have a look at the dokku-deployment-keys plugin on GitHub:
 http://github.com/cedricziel/dokku-deployment-keys
 

--- a/commands
+++ b/commands
@@ -88,9 +88,6 @@ print_explanation() {
     This command would automatically discover the hostkeys for github.com, add it to your known_hosts
     file for the mycoolapp app and will be compiled inside the slug on recompile.
 
-    $ dokku hostkeys:shared:autoadd github.com
-    This command would automatically discover the hostkeys for github.com and add it to your apps slug.
-
     You may as well want to have a look at the dokku-deployment-keys plugin on GitHub:
     http://github.com/cedricziel/dokku-deployment-keys
 

--- a/plugin.toml
+++ b/plugin.toml
@@ -1,0 +1,2 @@
+[plugin]
+description = "Manage hostkeys for your container environment"


### PR DESCRIPTION
When I deploy I get errors like the following:

```bash
$ g push production master
Total 0 (delta 0), reused 0 (delta 0)
remote: 2015/11/19 12:47:43 open /var/lib/dokku/plugins/available/deployment-keys/plugin.toml: no such file or directory
remote: 2015/11/19 12:47:43 open /var/lib/dokku/plugins/available/deployment-keys/plugin.toml: no such file or directory
remote: 2015/11/19 12:47:43 open /var/lib/dokku/plugins/available/hostkeys-plugin/plugin.toml: no such file or directory
-----> Cleaning up...
-----> Building app from herokuish...
-----> Adding BUILD_ENV to build environment...
remote: 2015/11/19 12:47:52 open /var/lib/dokku/plugins/available/deployment-keys/plugin.toml: no such file or directory
remote: 2015/11/19 12:47:52 open /var/lib/dokku/plugins/available/hostkeys-plugin/plugin.toml: no such file or directory
remote: 2015/11/19 12:47:53 open /var/lib/dokku/plugins/available/deployment-keys/plugin.toml: no such file or directory
remote: 2015/11/19 12:47:53 open /var/lib/dokku/plugins/available/hostkeys-plugin/plugin.toml: no such file or directory
```

So I added a `.toml` file to make it stop.

I also deleted a redundant command from the examples in the explanation and the readme.