### PR TITLE
Fix adding/deleting keys

### DIFF
--- a/commands
+++ b/commands
@@ -22,6 +22,8 @@ check_app() {
     echo "You must specify an app name"
     exit 1
   fi
+  check_exists
+  check_install_app
 }
 
 check_install() {
@@ -162,8 +164,6 @@ autoadd_shared_key() {
 add_app_key() {
   local HOSTKEY_TO_ADD_FOR_APP=$3 
   check_app
-  check_exists
-  check_install_app
   if [[ -n "$HOSTKEY_TO_ADD_FOR_APP" ]]; then
     echo $HOSTKEY_TO_ADD_FOR_APP >> "$APP_SPECIFIC_HOSTKEYS_FILE"
     echo "Added $HOSTKEY_TO_ADD_FOR_APP to the list of shared hostkeys"
@@ -174,8 +174,6 @@ add_app_key() {
 
 autoadd_app_key(){
   check_app
-  check_exists
-  check_install_app
   if [[ -n "$HOSTNAME_TO_ADD_APP" ]]; then
     ssh-keyscan -H "$HOSTNAME_TO_ADD_APP" >> "$APP_SPECIFIC_HOSTKEYS_FILE"
     echo "Added keys for $HOSTNAME_TO_ADD_APP"
@@ -187,8 +185,6 @@ autoadd_app_key(){
 delete_app_keys() {
   local HOSTNAME_TO_REMOVE_FOR_APP=$3
   check_app
-  check_exists
-  check_install_app
   if [[ -n "$HOSTNAME_TO_REMOVE_FOR_APP" ]]; then
     ssh-keygen -f "$APP_SPECIFIC_HOSTKEYS_FILE" -R "$HOSTNAME_TO_REMOVE_FOR_APP"
     rm "$APP_SPECIFIC_HOSTKEYS_FOLDER/known_hosts.old"
@@ -201,8 +197,6 @@ delete_app_keys() {
 
 print_keys_for_app() {
   check_app
-  check_exists
-  check_install_app
   print_shared_keys
   cat<<EOF
 

--- a/commands
+++ b/commands
@@ -2,12 +2,8 @@
 set -eo pipefail; [[ $DOKKU_TRACE ]] && set -x
 
 APP=$2
-SHARED_KEY_TO_ADD=$2
-SHARED_KEY_TO_ADD_APP=$3
 HOSTNAME_TO_ADD=$2
 HOSTNAME_TO_ADD_APP=$3
-HOSTNAME_TO_REMOVE=$2
-HOSTNAME_TO_REMOVE_APP=$3
 
 APP_SPECIFIC_HOSTKEYS_FOLDER="$DOKKU_ROOT/.hostkeys/$APP/.ssh"
 APP_SPECIFIC_HOSTKEYS_FILE="$APP_SPECIFIC_HOSTKEYS_FOLDER/known_hosts"
@@ -130,18 +126,20 @@ EOF
 }
 
 add_shared_key() {
+  local SHARED_HOSTKEY_TO_ADD=$2
   check_install
-  if [[ ! -n "$2" ]]; then
-    echo $SHARED_KEY_TO_ADD >> "$SHARED_HOSTKEYS_FILE"
-    echo "Added $SHARED_KEY_TO_ADD to the list of shared hostkeys"
+  if [[ -n "$SHARED_HOSTKEY_TO_ADD" ]]; then
+    echo $SHARED_HOSTKEY_TO_ADD >> "$SHARED_HOSTKEYS_FILE"
+    echo "Added $SHARED_HOSTKEY_TO_ADD to the list of shared hostkeys"
   else
     echo "Empty argument. Try again."
   fi
 }
 
 delete_shared_keys() {
+  local HOSTNAME_TO_REMOVE=$2
   check_install
-  if [[ ! -n "$2" ]]; then
+  if [[ -n "$HOSTNAME_TO_REMOVE" ]]; then
     ssh-keygen -f "$SHARED_HOSTKEYS_FILE" -R "$HOSTNAME_TO_REMOVE"
     rm "$SHARED_HOSTKEYS_FOLDER/known_hosts.old"
     echo "Deleted hostkey for $HOSTNAME_TO_REMOVE as well as the backup."
@@ -162,12 +160,13 @@ autoadd_shared_key() {
 }
 
 add_app_key() {
+  local HOSTKEY_TO_ADD_FOR_APP=$3 
   check_app
   check_exists
   check_install_app
-  if [[ ! -n "$3" ]]; then
-    echo $SHARED_KEY_TO_ADD_APP >> "$APP_SPECIFIC_HOSTKEYS_FILE"
-    echo "Added $SHARED_KEY_TO_ADD_APP to the list of shared hostkeys"
+  if [[ -n "$HOSTKEY_TO_ADD_FOR_APP" ]]; then
+    echo $HOSTKEY_TO_ADD_FOR_APP >> "$APP_SPECIFIC_HOSTKEYS_FILE"
+    echo "Added $HOSTKEY_TO_ADD_FOR_APP to the list of shared hostkeys"
   else
     echo "Empty argument. Try again."
   fi
@@ -186,13 +185,14 @@ autoadd_app_key(){
 }
 
 delete_app_keys() {
+  local HOSTNAME_TO_REMOVE_FOR_APP=$3
   check_app
   check_exists
   check_install_app
-  if [[ -n "$3" ]]; then
-    ssh-keygen -f "$APP_SPECIFIC_HOSTKEYS_FILE" -R "$HOSTNAME_TO_REMOVE_APP"
+  if [[ -n "$HOSTNAME_TO_REMOVE_FOR_APP" ]]; then
+    ssh-keygen -f "$APP_SPECIFIC_HOSTKEYS_FILE" -R "$HOSTNAME_TO_REMOVE_FOR_APP"
     rm "$APP_SPECIFIC_HOSTKEYS_FOLDER/known_hosts.old"
-    echo "Deleted hostkey for $HOSTNAME_TO_REMOVE as well as the backup."
+    echo "Deleted hostkey for $HOSTNAME_TO_REMOVE_FOR_APP as well as the backup."
   else
     > $APP_SPECIFIC_HOSTKEYS_FILE
     echo "Emptied the app specific hostkey file. Your app looses the specific keys on the next push. Make sure you add the required ones"

--- a/commands
+++ b/commands
@@ -5,10 +5,21 @@ APP=$2
 HOSTNAME_TO_ADD=$2
 HOSTNAME_TO_ADD_FOR_APP=$3
 
-APP_SPECIFIC_HOSTKEYS_FOLDER="$DOKKU_ROOT/.hostkeys/$APP/.ssh"
-APP_SPECIFIC_HOSTKEYS_FILE="$APP_SPECIFIC_HOSTKEYS_FOLDER/known_hosts"
 SHARED_HOSTKEYS_FOLDER="$DOKKU_ROOT/.hostkeys/shared/.ssh"
 SHARED_HOSTKEYS_FILE="$SHARED_HOSTKEYS_FOLDER/known_hosts"
+
+get_hostkeys_folder_for_app() {
+  local APP=$1
+  echo "$DOKKU_ROOT/.hostkeys/$APP/.ssh"  
+}
+
+get_hostkeys_file_path_for_app() {
+  local APP=$1
+  echo "$(get_hostkeys_folder_for_app "$APP")/known_hosts"
+}
+
+APP_SPECIFIC_HOSTKEYS_FOLDER="$(get_hostkeys_folder_for_app "$APP")"
+APP_SPECIFIC_HOSTKEYS_FILE="$(get_hostkeys_file_path_for_app "$APP")"
 
 check_exists() {
   if [[ ! -d "$DOKKU_ROOT/$APP" ]]; then

--- a/commands
+++ b/commands
@@ -157,7 +157,7 @@ delete_shared_keys() {
     rm "$SHARED_HOSTKEYS_FOLDER/known_hosts.old"
     echo "Deleted hostkey for $HOSTNAME_TO_REMOVE as well as the backup."
   else
-    > $SHARED_HOSTKEYS_FILE
+    true > $SHARED_HOSTKEYS_FILE
     echo "Emptied the shared hostkey file. All apps will loose the shared keys on next push. Make sure you add the required ones"
   fi
 }
@@ -214,7 +214,7 @@ delete_app_keys() {
     rm "$APP_SPECIFIC_HOSTKEYS_FOLDER/known_hosts.old"
     echo "Deleted hostkey for $HOSTNAME_TO_REMOVE_FOR_APP as well as the backup."
   else
-    > $APP_SPECIFIC_HOSTKEYS_FILE
+    true > $APP_SPECIFIC_HOSTKEYS_FILE
     echo "Emptied the app specific hostkey file. Your app looses the specific keys on the next push. Make sure you add the required ones"
   fi
 }

--- a/commands
+++ b/commands
@@ -1,10 +1,6 @@
 #!/usr/bin/env bash
 set -eo pipefail; [[ $DOKKU_TRACE ]] && set -x
 
-APP=$2
-HOSTNAME_TO_ADD=$2
-HOSTNAME_TO_ADD_FOR_APP=$3
-
 SHARED_HOSTKEYS_FOLDER="$DOKKU_ROOT/.hostkeys/shared/.ssh"
 SHARED_HOSTKEYS_FILE="$SHARED_HOSTKEYS_FOLDER/known_hosts"
 
@@ -18,10 +14,8 @@ get_hostkeys_file_path_for_app() {
   echo "$(get_hostkeys_folder_for_app "$APP")/known_hosts"
 }
 
-APP_SPECIFIC_HOSTKEYS_FOLDER="$(get_hostkeys_folder_for_app "$APP")"
-APP_SPECIFIC_HOSTKEYS_FILE="$(get_hostkeys_file_path_for_app "$APP")"
-
 check_exists() {
+  local APP=$1
   if [[ ! -d "$DOKKU_ROOT/$APP" ]]; then
     echo "App must exist before managing hostkeys for it"
     exit 1
@@ -29,12 +23,13 @@ check_exists() {
 }
 
 check_app() {
+  local APP=$1
   if [[ -z "$APP" ]]; then
     echo "You must specify an app name"
     exit 1
   fi
-  check_exists
-  check_install_app
+  check_exists "$APP"
+  check_install_app "$APP"
 }
 
 check_install() {
@@ -50,6 +45,11 @@ check_install() {
 }
 
 check_install_app() {
+  local APP=$1
+  local APP_SPECIFIC_HOSTKEYS_FOLDER
+  local APP_SPECIFIC_HOSTKEYS_FILE
+  APP_SPECIFIC_HOSTKEYS_FOLDER="$(get_hostkeys_folder_for_app "$APP")"
+  APP_SPECIFIC_HOSTKEYS_FILE="$(get_hostkeys_file_path_for_app "$APP")"
   if [[ ! -d "$APP_SPECIFIC_HOSTKEYS_FOLDER" ]]; then
     echo "No app specific keys folder available. creating.."
     mkdir -p "$APP_SPECIFIC_HOSTKEYS_FOLDER"
@@ -163,6 +163,7 @@ delete_shared_keys() {
 }
 
 autoadd_shared_key() {
+  local HOSTNAME_TO_ADD=$2
   check_install
   if [[ -n "$HOSTNAME_TO_ADD" ]]; then
     ssh-keyscan -H "$HOSTNAME_TO_ADD" >> "$SHARED_HOSTKEYS_FILE"
@@ -173,8 +174,11 @@ autoadd_shared_key() {
 }
 
 add_app_key() {
-  local HOSTKEY_TO_ADD_FOR_APP=$3 
-  check_app
+  local APP=$2
+  local HOSTKEY_TO_ADD_FOR_APP=$3
+  local APP_SPECIFIC_HOSTKEYS_FILE
+  APP_SPECIFIC_HOSTKEYS_FILE="$(get_hostkeys_file_path_for_app "$APP")" 
+  check_app "$APP"
   if [[ -n "$HOSTKEY_TO_ADD_FOR_APP" ]]; then
     echo $HOSTKEY_TO_ADD_FOR_APP >> "$APP_SPECIFIC_HOSTKEYS_FILE"
     echo "Added $HOSTKEY_TO_ADD_FOR_APP to the list of shared hostkeys"
@@ -184,7 +188,11 @@ add_app_key() {
 }
 
 autoadd_app_key(){
-  check_app
+  local APP=$2
+  local HOSTNAME_TO_ADD_FOR_APP=$3
+  local APP_SPECIFIC_HOSTKEYS_FILE
+  APP_SPECIFIC_HOSTKEYS_FILE="$(get_hostkeys_file_path_for_app "$APP")"
+  check_app "$APP"
   if [[ -n "$HOSTNAME_TO_ADD_FOR_APP" ]]; then
     ssh-keyscan -H "$HOSTNAME_TO_ADD_FOR_APP" >> "$APP_SPECIFIC_HOSTKEYS_FILE"
     echo "Added keys for $HOSTNAME_TO_ADD_FOR_APP"
@@ -194,8 +202,13 @@ autoadd_app_key(){
 }
 
 delete_app_keys() {
+  local APP=$2
   local HOSTNAME_TO_REMOVE_FOR_APP=$3
-  check_app
+  local APP_SPECIFIC_HOSTKEYS_FOLDER
+  local APP_SPECIFIC_HOSTKEYS_FILE
+  APP_SPECIFIC_HOSTKEYS_FOLDER="$(get_hostkeys_folder_for_app "$APP")"
+  APP_SPECIFIC_HOSTKEYS_FILE="$(get_hostkeys_file_path_for_app "$APP")"
+  check_app "$APP"
   if [[ -n "$HOSTNAME_TO_REMOVE_FOR_APP" ]]; then
     ssh-keygen -f "$APP_SPECIFIC_HOSTKEYS_FILE" -R "$HOSTNAME_TO_REMOVE_FOR_APP"
     rm "$APP_SPECIFIC_HOSTKEYS_FOLDER/known_hosts.old"
@@ -207,7 +220,10 @@ delete_app_keys() {
 }
 
 print_keys_for_app() {
-  check_app
+  local APP=$2
+  local APP_SPECIFIC_HOSTKEYS_FILE
+  APP_SPECIFIC_HOSTKEYS_FILE="$(get_hostkeys_file_path_for_app "$APP")"
+  check_app "$APP"
   print_shared_keys
   cat<<EOF
 
@@ -240,11 +256,11 @@ case "$1" in
     ;;
 
   hostkeys:shared:autoadd)
-    autoadd_shared_key
+    autoadd_shared_key "$@"
     ;;
 
   hostkeys:app:show)
-    print_keys_for_app
+    print_keys_for_app "$@"
     ;;
 
   hostkeys:app:add)
@@ -256,7 +272,7 @@ case "$1" in
     ;;
 
   hostkeys:app:autoadd)
-    autoadd_app_key
+    autoadd_app_key "$@"
     ;;
 
   help | hostkeys:help)

--- a/commands
+++ b/commands
@@ -3,7 +3,7 @@ set -eo pipefail; [[ $DOKKU_TRACE ]] && set -x
 
 APP=$2
 HOSTNAME_TO_ADD=$2
-HOSTNAME_TO_ADD_APP=$3
+HOSTNAME_TO_ADD_FOR_APP=$3
 
 APP_SPECIFIC_HOSTKEYS_FOLDER="$DOKKU_ROOT/.hostkeys/$APP/.ssh"
 APP_SPECIFIC_HOSTKEYS_FILE="$APP_SPECIFIC_HOSTKEYS_FOLDER/known_hosts"
@@ -174,9 +174,9 @@ add_app_key() {
 
 autoadd_app_key(){
   check_app
-  if [[ -n "$HOSTNAME_TO_ADD_APP" ]]; then
-    ssh-keyscan -H "$HOSTNAME_TO_ADD_APP" >> "$APP_SPECIFIC_HOSTKEYS_FILE"
-    echo "Added keys for $HOSTNAME_TO_ADD_APP"
+  if [[ -n "$HOSTNAME_TO_ADD_FOR_APP" ]]; then
+    ssh-keyscan -H "$HOSTNAME_TO_ADD_FOR_APP" >> "$APP_SPECIFIC_HOSTKEYS_FILE"
+    echo "Added keys for $HOSTNAME_TO_ADD_FOR_APP"
   else
     echo "Please enter the name of the host as argument"
   fi

--- a/pre-build
+++ b/pre-build
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
 set -eo pipefail; [[ $DOKKU_TRACE ]] && set -x
+# shellcheck source=/dev/null
 source "$PLUGIN_ENABLED_PATH/common/functions"
 APP="$1"
 IMAGE=$(get_app_image_name $APP)

--- a/pre-build
+++ b/pre-build
@@ -28,7 +28,7 @@ if [[ -f "$SHARED_KEY_FOLDER/known_hosts" ]]; then
   fi
 fi
 
-if [[ ! -z "$KNOWN_HOSTS_COMBINED" ]]; then
+if [[ -n "$KNOWN_HOSTS_COMBINED" ]]; then
   # 1. Create the .ssh folder
   id=$(docker run $DOKKU_GLOBAL_RUN_ARGS -d $IMAGE /bin/bash -c "mkdir -p -m 700 /app/.ssh")
   test $(docker wait $id) -eq 0

--- a/pre-build
+++ b/pre-build
@@ -21,7 +21,7 @@ fi
 
 if [[ -f "$SHARED_KEY_FOLDER/known_hosts" ]]; then
   dokku_log_verbose_quiet "Adding shared keys"
-  if ([[ -z "$KNOWN_HOSTS_COMBINED" ]]); then
+  if [[ -z "$KNOWN_HOSTS_COMBINED" ]]; then
     KNOWN_HOSTS_COMBINED="$KNOWN_HOSTS_COMBINED"$(cat "$SHARED_KEY_FOLDER/known_hosts")
   else
     KNOWN_HOSTS_COMBINED="$KNOWN_HOSTS_COMBINED"$'\n'$(cat "$SHARED_KEY_FOLDER/known_hosts")


### PR DESCRIPTION
Remove use of global variables based on positional parameters

- Positional parameters are now checked in the action context, and stored in local variables 
- Some wrong conditions on check have been fixed in `add_shared_key()`, `delete_shared_keys()`, `add_app_key()` and `delete_app_keys`.

Fixes #30