### PR TITLE
fix: set correct PLUGIN_CONFIG_ROOT

### DIFF
--- a/install
+++ b/install
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 set -eo pipefail
 [[ $DOKKU_TRACE ]] && set -x
+source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/config"
 
 trigger-hostkeys-install() {
   declare desc="installs the hostkeys"


### PR DESCRIPTION
Closes #38

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved reliability of the installation process by ensuring required directories are always created during setup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->